### PR TITLE
fix: extra quotation marks will be added when execute edit-save action repeatly

### DIFF
--- a/src/components/json-node.tsx
+++ b/src/components/json-node.tsx
@@ -9,7 +9,8 @@ import {
 	isObject,
 	isReactComponent,
 	safeCall,
-	stringifyForCopying
+	stringifyForCopying,
+	resolveEvalFailedNewValue
 } from '../utils'
 import ObjectNode from './object-node'
 import LongString from './long-string'
@@ -68,6 +69,7 @@ export default function JsonNode({ node, depth, deleteHandle: _deleteHandle, nam
 				valueRef.current?.focus()
 			})
 		}
+
 		const done = () => {
 			const newValue = valueRef.current!.innerText
 
@@ -76,7 +78,8 @@ export default function JsonNode({ node, depth, deleteHandle: _deleteHandle, nam
 
 				if (editHandle) editHandle(name!, evalValue, node)
 			} catch (e) {
-				if (editHandle) editHandle(name!, newValue, node)
+				const trimmedStringValue = resolveEvalFailedNewValue(type, newValue);
+				if (editHandle) editHandle(name!, trimmedStringValue, node)
 			}
 
 			setEditing(false)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,3 +91,10 @@ export function customDelete(customOptions?: CustomizeOptions) {
 export function customCopy(customOptions?: CustomizeOptions) {
 	return !customOptions || customOptions.enableClipboard === undefined || !!customOptions.enableClipboard
 }
+
+export function resolveEvalFailedNewValue(type: string, value: string) {
+	if (type === 'string') {
+		return value.trim().replace(/^\"([\s\S]+?)\"$/, '$1');
+	}
+	return value;
+}


### PR DESCRIPTION
Reproduce
1. Input a char `"`, and save;
2. Click the tick icon to save, the tree node value will be `"`;
3. Edit and save again, the  tree node value will be  `"""`;
4. repeat again.... quotation marks grows... :)

Fixes
By trimming the extra quotes when `eval(newValue)` throws an error to prevent the extra quotes.