### PR TITLE
pretty-print copied json by default

### DIFF
--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -11,7 +11,7 @@ export default function CopyButton({ node }: { node: any }) {
 	) : (
 		<CopySVG
 			onClick={event => {
-				const value = stringifyForCopying(node)
+				const value = stringifyForCopying(node, 4)
 
 				event.stopPropagation()
 				navigator.clipboard.writeText(value)


### PR DESCRIPTION
I suggest to default to pretty-printed json when copying a node.