### PR TITLE
fix css sideEffects for issue #20

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,5 @@
 	"bugs": {
 		"url": "https://github.com/YYsuni/react18-json-view/issues"
 	},
-	"sideEffects": false
+	"sideEffects": ["*.css"]
 }


### PR DESCRIPTION
#20 I have the same issue. 

The following option cause webpack to ignore unused css module when packaging.

package.json
```json
"sideEffects": false => "sideEffects": ["*.css"]
```