### PR TITLE
fix: fix css bug

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -87,6 +87,7 @@
 	outline: none;
 	border: none;
 	cursor: pointer;
+	color: inherit;
 }
 .json-view .cursor-pointer {
 	cursor: pointer;


### PR DESCRIPTION
if not set button `color` property, it will be decide by `User Agent Stylesheet `

![CleanShot 2024-03-28 at 14 52 13@2x](https://github.com/YYsuni/react18-json-view/assets/44634134/f491e33e-f0be-427b-8900-9f6acd8d7ff7)


Copilot generate summary: 
This pull request includes a minor change to the `src/style.css` file. The change adds a new CSS property `color: inherit;` to a CSS rule, which allows the text color to be inherited from its parent element.