### PR TITLE
fix: allow types beside strings to inherit custom classname

### DIFF
--- a/src/components/json-node.tsx
+++ b/src/components/json-node.tsx
@@ -170,9 +170,7 @@ export default function JsonNode({ node, depth, deleteHandle: _deleteHandle, ind
 		)
 
 		let className = 'json-view--string'
-
-		if (typeof (customReturn as CustomizeOptions)?.className === 'string') className += ' ' + (customReturn as CustomizeOptions).className
-
+		
 		switch (type) {
 			case 'number':
 			case 'bigint':
@@ -185,6 +183,9 @@ export default function JsonNode({ node, depth, deleteHandle: _deleteHandle, ind
 				className = 'json-view--null'
 				break
 		}
+		
+		if (typeof (customReturn as CustomizeOptions)?.className === 'string') className += ' ' + (customReturn as CustomizeOptions).className
+
 		if (deleting) className += ' json-view--deleting'
 
 		let displayValue = String(node)


### PR DESCRIPTION
Here's just an example image showing that a custom classname when customizing nodes doesn't apply to null, or boolean types.

<img width="473" alt="Screenshot 2024-08-05 at 17 23 50" src="https://github.com/user-attachments/assets/7525aea9-4a6b-49fe-ac79-92b5802d94e1">
