### PR TITLE
feat: return parent paths on edit

### DIFF
--- a/src/components/large-array-node.tsx
+++ b/src/components/large-array-node.tsx
@@ -11,12 +11,13 @@ interface Props {
 	node: Array<any>
 	depth: number
 	index: number
-	deleteHandle?: (_: string | number) => void
+	deleteHandle?: (_: string | number, currentPath: string[]) => void
 	customOptions?: CustomizeOptions
 	startIndex: number
+	parentPath: string[]
 }
 
-export default function LargeArrayNode({ originNode, node, depth, index, deleteHandle: _deleteSelf, customOptions, startIndex }: Props) {
+export default function LargeArrayNode({ originNode, node, depth, index, deleteHandle: _deleteSelf, customOptions, startIndex, parentPath }: Props) {
 	const { enableClipboard, src, onEdit, onChange, forceUpdate, displaySize, CustomOperation } = useContext(JsonViewContext)
 
 	const [fold, setFold] = useState(true)
@@ -32,9 +33,10 @@ export default function LargeArrayNode({ originNode, node, depth, index, deleteH
 					depth,
 					src,
 					indexOrName,
-					parentType: 'array'
+					parentType: 'array',
+					parentPath
 				})
-			if (onChange) onChange({ type: 'edit', depth, src, indexOrName, parentType: 'array' })
+			if (onChange) onChange({ type: 'edit', depth, src, indexOrName, parentType: 'array', parentPath })
 			forceUpdate()
 		},
 		[node, onEdit, onChange, forceUpdate]
@@ -43,6 +45,7 @@ export default function LargeArrayNode({ originNode, node, depth, index, deleteH
 	// Delete property
 	const deleteHandle = (index: number | string) => {
 		originNode.splice(index as number, 1)
+		if (_deleteSelf) _deleteSelf(index, parentPath)
 		forceUpdate()
 	}
 
@@ -57,7 +60,7 @@ export default function LargeArrayNode({ originNode, node, depth, index, deleteH
 			)}
 
 			{!fold && enableClipboard && customCopy(customOptions) && <CopyButton node={node} />}
-			{ typeof CustomOperation === 'function' ?  <CustomOperation node={node}  /> : null }
+			{typeof CustomOperation === 'function' ? <CustomOperation node={node} /> : null}
 		</>
 	)
 
@@ -78,6 +81,7 @@ export default function LargeArrayNode({ originNode, node, depth, index, deleteH
 							parent={node}
 							deleteHandle={deleteHandle}
 							editHandle={editHandle}
+							parentPath={parentPath}
 						/>
 					))}
 				</div>
@@ -88,12 +92,6 @@ export default function LargeArrayNode({ originNode, node, depth, index, deleteH
 			)}
 
 			<span>{']'}</span>
-
-			{/* {fold && ifDisplay(displaySize, depth, fold) && (
-				<span onClick={() => setFold(false)} className='jv-size'>
-					{objectSize(node)} Items
-				</span>
-			)} */}
 		</div>
 	)
 }

--- a/src/components/large-array.tsx
+++ b/src/components/large-array.tsx
@@ -1,24 +1,25 @@
 import { useContext, useEffect, useState } from 'react'
-import LargeArrayNode from './large-array-node'
 import { JsonViewContext } from './json-view'
-import { CustomizeOptions } from '../types'
-import { customAdd, customCopy, customDelete, editableAdd, editableDelete, ifDisplay, isCollapsed, isCollapsed_largeArray } from '../utils'
+import { isCollapsed_largeArray, ifDisplay, editableAdd, editableDelete, customAdd, customCopy, customDelete } from '../utils'
 import { ReactComponent as AngleDownSVG } from '../svgs/angle-down.svg'
 import CopyButton from './copy-button'
 import { ReactComponent as DeleteSVG } from '../svgs/trash.svg'
 import { ReactComponent as AddSVG } from '../svgs/add-square.svg'
 import { ReactComponent as DoneSVG } from '../svgs/done.svg'
 import { ReactComponent as CancelSVG } from '../svgs/cancel.svg'
+import type { CustomizeOptions } from '../types'
+import LargeArrayNode from './large-array-node'
 
 interface Props {
 	node: Array<any>
 	depth: number
 	indexOrName?: number | string
-	deleteHandle?: (_: string | number) => void
+	deleteHandle?: (_: string | number, currentPath: string[]) => void
 	customOptions?: CustomizeOptions
+	parentPath: string[]
 }
 
-export default function LargeArray({ node, depth, deleteHandle: _deleteSelf, indexOrName, customOptions }: Props) {
+export default function LargeArray({ node, depth, deleteHandle: _deleteSelf, indexOrName, customOptions, parentPath }: Props) {
 	const nestCollapsedArray: any[] = []
 	for (let i = 0; i < node.length; i += 100) {
 		nestCollapsedArray.push(node.slice(i, i + 100))
@@ -36,15 +37,16 @@ export default function LargeArray({ node, depth, deleteHandle: _deleteSelf, ind
 	const [deleting, setDeleting] = useState(false)
 	const deleteSelf = () => {
 		setDeleting(false)
-		if (_deleteSelf) _deleteSelf(indexOrName!)
-		if (onDelete) onDelete({ value: node, depth, src, indexOrName: indexOrName!, parentType: 'array' })
+		if (_deleteSelf) _deleteSelf(indexOrName!, parentPath)
+		if (onDelete) onDelete({ value: node, depth, src, indexOrName: indexOrName!, parentType: 'array', parentPath })
 		if (onChange)
 			onChange({
 				type: 'delete',
 				depth,
 				src,
 				indexOrName: indexOrName!,
-				parentType: 'array'
+				parentType: 'array',
+				parentPath
 			})
 	}
 
@@ -53,8 +55,8 @@ export default function LargeArray({ node, depth, deleteHandle: _deleteSelf, ind
 	const add = () => {
 		const arr = node as unknown as any[]
 		arr.push(null)
-		if (onAdd) onAdd({ indexOrName: arr.length - 1, depth, src, parentType: 'array' })
-		if (onChange) onChange({ type: 'add', indexOrName: arr.length - 1, depth, src, parentType: 'array' })
+		if (onAdd) onAdd({ indexOrName: arr.length - 1, depth, src, parentType: 'array', parentPath })
+		if (onChange) onChange({ type: 'add', indexOrName: arr.length - 1, depth, src, parentType: 'array', parentPath })
 		forceUpdate()
 	}
 
@@ -89,7 +91,7 @@ export default function LargeArray({ node, depth, deleteHandle: _deleteSelf, ind
 			{!fold && !isEditing && editableDelete(editable) && customDelete(customOptions) && _deleteSelf && (
 				<DeleteSVG className='json-view--edit' onClick={() => setDeleting(true)} />
 			)}
-			{ typeof CustomOperation === 'function' ?  <CustomOperation node={node}  /> : null }
+			{typeof CustomOperation === 'function' ? <CustomOperation node={node} /> : null}
 		</>
 	)
 
@@ -102,7 +104,17 @@ export default function LargeArray({ node, depth, deleteHandle: _deleteSelf, ind
 			{!fold ? (
 				<div className='jv-indent'>
 					{nestCollapsedArray.map((item, index) => (
-						<LargeArrayNode key={String(indexOrName) + String(index)} originNode={node} node={item} depth={depth} index={index} startIndex={index * 100} />
+						<LargeArrayNode
+							key={String(indexOrName) + String(index)}
+							originNode={node}
+							node={item}
+							depth={depth}
+							index={index}
+							startIndex={index * 100}
+							deleteHandle={_deleteSelf}
+							customOptions={customOptions}
+							parentPath={parentPath}
+						/>
 					))}
 				</div>
 			) : (

--- a/src/components/name-value.tsx
+++ b/src/components/name-value.tsx
@@ -8,11 +8,12 @@ interface Props {
 	value: any
 	depth: number
 	parent?: Record<string, any> | Array<any>
-	deleteHandle: (indexOrName: string | number) => void
-	editHandle: (indexOrName: string | number, newValue: any, oldValue: any) => void
+	parentPath: string[]
+	deleteHandle: (indexOrName: string | number, parentPath: string[]) => void
+	editHandle: (indexOrName: string | number, newValue: any, oldValue: any, parentPath: string[]) => void
 }
 
-export default function NameValue({ indexOrName, value, depth, parent, deleteHandle, editHandle }: Props) {
+export default function NameValue({ indexOrName, value, depth, parent, deleteHandle, editHandle, parentPath }: Props) {
 	const { displayArrayIndex } = useContext(JsonViewContext)
 	const isArray = Array.isArray(parent)
 
@@ -25,7 +26,15 @@ export default function NameValue({ indexOrName, value, depth, parent, deleteHan
 			) : (
 				<></>
 			)}
-			<JsonNode node={value} depth={depth + 1} deleteHandle={deleteHandle} editHandle={editHandle} parent={parent} indexOrName={indexOrName} />
+			<JsonNode
+				node={value}
+				depth={depth + 1}
+				deleteHandle={(indexOrName, parentPath) => deleteHandle(indexOrName, parentPath)}
+				editHandle={(indexOrName, newValue, oldValue, parentPath) => editHandle(indexOrName, newValue, oldValue, parentPath)}
+				parent={parent}
+				indexOrName={indexOrName}
+				parentPath={parentPath}
+			/>
 		</div>
 	)
 }

--- a/src/stories/editable.stories.tsx
+++ b/src/stories/editable.stories.tsx
@@ -27,21 +27,24 @@ export default {
 			obj: {
 				k1: 123,
 				k2: '123',
-				k3: false
+				k3: false,
+				nested: {
+					k4: 'nested'
+				}
 			},
 			arr: ['string', 123456, false, null]
 		},
-		onEdit: ({ newValue, src, oldValue, indexOrName }) => {
-			console.log('[onEdit]', indexOrName, newValue, oldValue, src)
+		onEdit: ({ newValue, src, oldValue, indexOrName, parentPath }) => {
+			console.log('[onEdit]', indexOrName, newValue, oldValue, src, parentPath)
 		},
-		onDelete: ({ value, src, indexOrName }) => {
-			console.log('[onDelete]', indexOrName, value, src)
+		onDelete: ({ value, src, indexOrName, parentPath }) => {
+			console.log('[onDelete]', indexOrName, value, src, parentPath)
 		},
-		onAdd: ({ src, indexOrName }) => {
-			console.log('[onAdd]', indexOrName, src)
+		onAdd: ({ src, indexOrName, parentPath }) => {
+			console.log('[onAdd]', indexOrName, src, parentPath)
 		},
-		onChange: ({ src, indexOrName }) => {
-			console.log('[onChange]', indexOrName, src)
+		onChange: ({ src, indexOrName, parentPath }) => {
+			console.log('[onChange]', indexOrName, src, parentPath)
 		}
 	},
 	decorators: [

--- a/website/src/contents/editable.tsx
+++ b/website/src/contents/editable.tsx
@@ -69,7 +69,10 @@ export default function Editable() {
 						obj: {
 							k1: 123,
 							k2: '123',
-							k3: false
+							k3: false,
+							nested: {
+								k4: 'nested'
+							}
 						},
 						arr: ['string', 123456, false, null],
 						largeArr: new Array(Math.trunc(Math.random() * 1000) + 800).fill((Math.random() * 10).toFixed(2))


### PR DESCRIPTION
This PR added an implementation of returning a variable of `parentPath` in the functions of `onEdit`, `OnDelete`, `onAdd` and `OnChange`. This will allow us to correctly indicate which field in the JSON is being edited

### Example

![image](https://github.com/user-attachments/assets/57dfaa2d-3c32-4124-bfb9-e31288684e74)

When `obj.nested.k4` is edited, the `onEdit` will return params as such 

```json
{
    "newValue": "lorem",
    "oldValue": "nested",
    "depth": 3,
    "src": {...},
    "indexOrName": "k4",
    "parentType": "object",
    "parentPath": [
        "obj",
        "nested"
    ]
}
```